### PR TITLE
ci(etapa-1): configura job de testes automatizados no GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: CI/CD Pipeline — TMDB App
+
+on:
+  push:
+    branches:
+      - release
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: '🧪 Testes Automatizados'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: '📥 Checkout do Código'
+        uses: actions/checkout@v4
+
+      - name: '⚙️ Configurar Node.js 20'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: '📦 Instalar Dependências'
+        run: npm ci
+
+      - name: '✅ Executar Testes'
+        run: npm test -- --watchAll=false --passWithNoTests


### PR DESCRIPTION
O que foi feito
Implementa a Etapa 1 do pipeline de CI/CD: job de testes
automatizados no GitHub Actions.

Alterações
- Criação do arquivo .github/workflows/main.yml
- Job test configurado com Node.js 20 e cache de npm
- Instalação de dependências via npm ci
- Execução de npm test em modo não-interativo
- Gatilhos: push na branch release e workflow_dispatch

Como Testar
1. Acesse a aba Actions após o merge
2. Execute manualmente via Run workflow
3. Verifique que o job conclui com 

Checklist
- Workflow dispara em push na branch release
- Node.js 20 configurado com cache
- npm ci utilizado
- Testes em modo não-interativo

Closes #1